### PR TITLE
Export native fetch in node and add native boolean export

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,25 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/tests/esbuild"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/tests/jest"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/tests/node"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/tests/rollup"
+    schedule:
+      interval: "daily"
   # Enable updates to github actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+ 

--- a/lib/browser.cjs
+++ b/lib/browser.cjs
@@ -3,5 +3,6 @@ module.exports = {
   Headers: globalThis.Headers,
   Response: globalThis.Response,
   Request: globalThis.Request,
-  type: 'browser.cjs'
+  type: 'browser.cjs',
+  native: true
 }

--- a/lib/browser.mjs
+++ b/lib/browser.mjs
@@ -1,5 +1,6 @@
 const fetch = window.fetch
 const type = 'browser.mjs'
+const native = true
 
 const Headers = globalThis.Headers
 const Response = globalThis.Response
@@ -10,5 +11,6 @@ export {
   type,
   Headers,
   Response,
-  Request
+  Request,
+  native
 }

--- a/lib/node.cjs
+++ b/lib/node.cjs
@@ -1,8 +1,9 @@
 const undici = require('undici')
 
-exports.fetch = undici.fetch
-exports.Headers = undici.Headers
-exports.Response = undici.Response
-exports.Request = undici.Request
+exports.fetch = globalThis?.fetch ?? undici.fetch
+exports.Headers = globalThis?.Headers ?? undici.Headers
+exports.Response = globalThis?.Response ?? undici.Response
+exports.Request = globalThis?.Request ?? undici.Request
 
 exports.type = 'node.cjs'
+exports.native = globalThis?.fetch != null

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "auto-changelog": "^2.2.0",
     "gh-release": "^6.0.0",
     "npm-run-all2": "^5.0.0",
+    "semver": "^7.3.7",
     "standard": "^17.0.0"
   },
   "homepage": "https://github.com/bcomnes/fetch-undici",

--- a/tests/esbuild/esbuild-app.js
+++ b/tests/esbuild/esbuild-app.js
@@ -1,3 +1,3 @@
-import { type } from 'fetch-undici'
+import { type, native } from 'fetch-undici'
 
-export { type }
+export { type, native }

--- a/tests/esbuild/esbuild.test.js
+++ b/tests/esbuild/esbuild.test.js
@@ -36,7 +36,8 @@ tap.test('test build with esbuild', async t => {
 
   await writeFile(join(dir, 'package.json'), '{ "type": "module" }')
 
-  const { type } = await import(join(dir, 'esbuild-app.js'))
+  const { type, native } = await import(join(dir, 'esbuild-app.js'))
   tap.equal(type, 'browser.mjs')
+  tap.equal(native, true)
   await cleanup()
 })

--- a/tests/esbuild/package.json
+++ b/tests/esbuild/package.json
@@ -12,10 +12,10 @@
   "license": "MIT",
   "dependencies": {
     "desm": "^1.2.0",
-    "esbuild": "^0.12.25",
+    "esbuild": "^0.14.39",
     "fetch-undici": "../../.",
-    "jsdom": "^17.0.0",
+    "jsdom": "^19.0.0",
     "p-temporary-directory": "^1.1.1",
-    "tap": "^15.0.9"
+    "tap": "^16.2.0"
   }
 }

--- a/tests/jest/jsdom.test.js
+++ b/tests/jest/jsdom.test.js
@@ -3,9 +3,15 @@
  * @jest-environment jsdom
  */
 
-const { fetch, type } = require('fetch-undici')
+const process = require('process')
+const semver = require('semver')
+const { fetch, type, native } = require('fetch-undici')
 
 test('jsdom in mjs', () => {
   expect(type).toBe('node.cjs')
   expect(fetch).toBeDefined()
+
+  const supportsFetch = semver.satisfies(process.version, '>=18.0.0')
+  if (supportsFetch) expect(native).toBe(true)
+  else expect(native).toBe(false)
 })

--- a/tests/jest/node.test.js
+++ b/tests/jest/node.test.js
@@ -1,8 +1,14 @@
 /* eslint-env jest */
 
-const { fetch, type } = require('fetch-undici')
+const process = require('process')
+const semver = require('semver')
+const { fetch, type, native } = require('fetch-undici')
 
 test('node in cjs', () => {
   expect(type).toBe('node.cjs')
   expect(fetch).toBeDefined()
+
+  const supportsFetch = semver.satisfies(process.version, '>=18.0.0')
+  if (supportsFetch) expect(native).toBe(true)
+  else expect(native).toBe(false)
 })

--- a/tests/jest/package.json
+++ b/tests/jest/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "fetch-undici": "../../.",
-    "jest": "^27.1.1"
+    "jest": "^28.1.0"
   }
 }

--- a/tests/node/node.test.cjs
+++ b/tests/node/node.test.cjs
@@ -1,7 +1,13 @@
 const tap = require('tap')
-const { type, fetch } = require('fetch-undici')
+const process = require('process')
+const semver = require('semver')
+const { type, fetch, native } = require('fetch-undici')
 
 tap.test('node gets undici cjs', async t => {
   t.equal(type, 'node.cjs')
   t.ok(fetch)
+
+  const supportsFetch = semver.satisfies(process.version, '>=18.0.0')
+  if (supportsFetch) t.true(native, 'exported native fetch in node versions >=18')
+  else t.false(native, 'exported undici fetch in node versions <18')
 })

--- a/tests/node/node.test.mjs
+++ b/tests/node/node.test.mjs
@@ -1,7 +1,13 @@
 import tap from 'tap'
-import { type, fetch } from 'fetch-undici'
+import process from 'process'
+import semver from 'semver'
+import { type, fetch, native } from 'fetch-undici'
 
 tap.test('node esm gets undici cjs', async t => {
   t.equal(type, 'node.cjs')
   t.ok(fetch)
+
+  const supportsFetch = semver.satisfies(process.version, '>=18.0.0')
+  if (supportsFetch) t.true(native, 'exported native fetch in node versions >=18')
+  else t.false(native, 'exported undici fetch in node versions <18')
 })

--- a/tests/node/package.json
+++ b/tests/node/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "fetch-undici": "../../.",
-    "tap": "^15.0.9"
+    "tap": "^16.2.0"
   }
 }

--- a/tests/rollup/package.json
+++ b/tests/rollup/package.json
@@ -11,13 +11,13 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "fetch-undici": "../../.",
     "rollup": "^2.56.3",
     "desm": "^1.2.0",
-    "jsdom": "^17.0.0",
+    "jsdom": "^19.0.0",
     "p-temporary-directory": "^1.1.1",
-    "tap": "^15.0.9"
+    "tap": "^16.2.0"
   }
 }

--- a/tests/rollup/rollup-app.js
+++ b/tests/rollup/rollup-app.js
@@ -1,3 +1,3 @@
-import { fetch, type } from 'fetch-undici'
+import { fetch, type, native } from 'fetch-undici'
 
-export { type, fetch }
+export { type, fetch, native }

--- a/tests/rollup/rollup.test.js
+++ b/tests/rollup/rollup.test.js
@@ -42,7 +42,8 @@ tap.test('test build with esbuild', async t => {
 
   await writeFile(join(dir, 'package.json'), '{ "type": "module" }')
 
-  const { type } = await import(join(dir, 'rollup-app.js'))
+  const { type, native } = await import(join(dir, 'rollup-app.js'))
   tap.equal(type, 'browser.mjs')
+  tap.true(native, 'native browser export in rollup')
   await cleanup()
 })


### PR DESCRIPTION
BREAKING CHANGE: This exports native fetch from globalThis in node environments. You will now get fetch if it exists on globalThis. If you polyfill this, it will return whatever value is polyfilled. Don't mix fetch polyfills unless you want to have a bad time.