### PR TITLE
Exclude tests from tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bcomnes/fetch-undici/issues"
   },
   "dependencies": {
-    "undici": "^6.0.1"
+    "undici": "^6.19.8"
   },
   "devDependencies": {
     "auto-changelog": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
     "browser": "./lib/browser.mjs",
     "node": "./lib/node.cjs"
   },
+  "files": [
+    "lib/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/bcomnes/fetch-undici.git"


### PR DESCRIPTION
Normally I prefer to publish everything in my tarballs as a safeguard for users against me nuking my GitHub repos (It happens more often than one might think!), but in this case, there isn't much here besides some tricky export labor, so re-creating it would be very easy.

Closes #84